### PR TITLE
✨ Remove using rectangular images as model inputs

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,314 +1,191 @@
 name: yolov7
 channels:
   - pytorch
-  - conda-forge
   - defaults
 dependencies:
-  - _libgcc_mutex=0.1=conda_forge
-  - _openmp_mutex=4.5=2_kmp_llvm
-  - aiohttp=3.8.3=py38h0a891b7_1
-  - aiohttp-retry=2.8.3=pyhd8ed1ab_0
-  - aiosignal=1.3.1=pyhd8ed1ab_0
-  - amqp=5.1.1=pyhd8ed1ab_0
-  - antlr-python-runtime=4.9.3=pyhd8ed1ab_1
-  - appdirs=1.4.4=pyh9f0ad1d_0
-  - async-timeout=4.0.2=pyhd8ed1ab_0
-  - asyncssh=2.12.0=pyhd8ed1ab_0
-  - atk-1.0=2.38.0=hd4edc92_1
-  - attrs=22.1.0=pyh71513ae_1
-  - backports=1.0=pyhd8ed1ab_3
-  - backports.functools_lru_cache=1.6.4=pyhd8ed1ab_0
-  - billiard=3.6.4.0=py38h0a891b7_3
+  - _libgcc_mutex=0.1=main
+  - _openmp_mutex=5.1=1_gnu
   - blas=1.0=mkl
-  - brotlipy=0.7.0=py38h0a891b7_1005
-  - bzip2=1.0.8=h7f98852_4
-  - c-ares=1.18.1=h7f98852_0
-  - ca-certificates=2022.9.24=ha878542_0
-  - cached-property=1.5.2=hd8ed1ab_1
-  - cached_property=1.5.2=pyha770c72_1
-  - cachetools=5.2.0=pyhd8ed1ab_0
-  - cairo=1.16.0=ha61ee94_1012
-  - celery=5.2.7=pyhd8ed1ab_0
-  - certifi=2022.9.24=pyhd8ed1ab_0
-  - cffi=1.15.1=py38h4a40e3a_2
-  - charset-normalizer=2.1.1=pyhd8ed1ab_0
-  - click=8.1.3=py38h578d9bd_1
-  - click-didyoumean=0.3.0=pyhd8ed1ab_0
-  - click-plugins=1.1.1=py_0
-  - click-repl=0.2.0=pyhd8ed1ab_0
-  - colorama=0.4.6=pyhd8ed1ab_0
-  - commonmark=0.9.1=py_0
-  - conda=22.9.0=py38h578d9bd_2
-  - conda-package-handling=1.9.0=py38h0a891b7_1
-  - cryptography=38.0.3=py38h80a4ca7_0
-  - cudatoolkit=11.3.1=h9edb442_10
-  - cudnn=8.1.0.77=h90431f1_0
-  - dataclasses=0.8=pyhc8e2a94_3
-  - decorator=5.1.1=pyhd8ed1ab_0
-  - dictdiffer=0.9.0=pyhd8ed1ab_0
-  - diskcache=5.4.0=pyhd8ed1ab_0
-  - dulwich=0.20.50=py38h0a891b7_0
-  - dvc-gdrive=2.19.0=pyhd8ed1ab_0
-  - dvc-http=2.27.2=pyhd8ed1ab_0
-  - dvclive=1.0.1=pyhd8ed1ab_0
-  - expat=2.5.0=h27087fc_0
+  - brotlipy=0.7.0=py38h27cfd23_1003
+  - bzip2=1.0.8=h7b6447c_0
+  - ca-certificates=2022.10.11=h06a4308_0
+  - certifi=2022.9.24=py38h06a4308_0
+  - cffi=1.15.1=py38h5eee18b_2
+  - charset-normalizer=2.0.4=pyhd3eb1b0_0
+  - cryptography=38.0.1=py38h9ce1e76_0
+  - cudatoolkit=11.3.1=h2bc3f7f_2
   - ffmpeg=4.3=hf484d3e_0
-  - filelock=3.8.0=pyhd8ed1ab_0
-  - flatten-dict=0.4.2=pyhd8ed1ab_1
-  - flufl.lock=7.1=pyhd8ed1ab_0
-  - fmt=9.1.0=h924138e_0
-  - font-ttf-dejavu-sans-mono=2.37=hab24e00_0
-  - font-ttf-inconsolata=3.000=h77eed37_0
-  - font-ttf-source-code-pro=2.038=h77eed37_0
-  - font-ttf-ubuntu=0.83=hab24e00_0
-  - fontconfig=2.14.0=h8e229c2_0
-  - fonts-conda-ecosystem=1=0
-  - fonts-conda-forge=1=0
-  - freetype=2.10.4=h0708190_1
-  - fribidi=1.0.10=h36c2ea0_0
-  - frozenlist=1.3.3=py38h0a891b7_0
-  - fsspec=2022.11.0=pyhd8ed1ab_0
-  - funcy=1.17=pyhd8ed1ab_0
-  - future=0.18.2=pyhd8ed1ab_6
-  - gdk-pixbuf=2.42.8=hff1cb4f_0
-  - gettext=0.21.1=h27087fc_0
-  - giflib=5.2.1=h36c2ea0_2
-  - gitpython=3.1.29=pyhd8ed1ab_0
-  - gmp=6.2.1=h58526e2_0
-  - gnutls=3.6.13=h85f3911_1
-  - google-api-core=2.10.2=pyhd8ed1ab_0
-  - google-api-python-client=2.66.0=pyhd8ed1ab_0
-  - google-auth=2.14.1=pyh1a96a4e_0
-  - google-auth-httplib2=0.1.0=pyhd8ed1ab_1
-  - grandalf=0.6=py_0
-  - graphite2=1.3.13=h58526e2_1001
-  - graphviz=5.0.0=h5abf519_0
-  - gtk2=2.24.33=h90689f9_2
-  - gts=0.7.6=h64030ff_2
-  - harfbuzz=5.1.0=hf9f4e7c_0
-  - httplib2=0.21.0=pyhd8ed1ab_0
-  - hydra-core=1.2.0=pyhd8ed1ab_0
-  - icu=70.1=h27087fc_0
-  - idna=3.4=pyhd8ed1ab_0
-  - importlib-metadata=5.0.0=pyha770c72_1
-  - importlib_resources=5.10.0=pyhd8ed1ab_0
+  - freetype=2.12.1=h4a9f257_0
+  - giflib=5.2.1=h7b6447c_0
+  - gmp=6.2.1=h295c915_3
+  - gnutls=3.6.15=he1e5248_0
+  - idna=3.4=py38h06a4308_0
   - intel-openmp=2021.4.0=h06a4308_3561
-  - iterative-telemetry=0.0.6=pyhd8ed1ab_0
-  - jbig=2.1=h7f98852_2003
-  - jpeg=9e=h166bdaf_1
-  - keyutils=1.6.1=h166bdaf_0
-  - kombu=5.2.4=py38h578d9bd_2
-  - krb5=1.19.3=h08a2579_0
-  - lame=3.100=h7f98852_1001
-  - lcms2=2.12=hddcbb42_0
+  - jpeg=9e=h7f8727e_0
+  - lame=3.100=h7b6447c_0
+  - lcms2=2.12=h3be6417_0
   - ld_impl_linux-64=2.38=h1181459_1
-  - lerc=2.2.1=h9c3ff4c_0
-  - libarchive=3.5.2=hada088e_3
-  - libcurl=7.86.0=h2283fc2_1
-  - libdeflate=1.7=h7f98852_5
-  - libedit=3.1.20191231=he28a2e2_2
-  - libev=4.33=h516909a_1
-  - libffi=3.4.2=h295c915_4
-  - libgcc-ng=12.2.0=h65d4601_19
-  - libgd=2.3.3=h18fbbfe_3
-  - libgit2=1.5.0=hdb3ecda_1
-  - libglib=2.74.1=h606061b_1
-  - libiconv=1.17=h166bdaf_0
-  - libmamba=1.0.0=h9eff5f0_2
-  - libmambapy=1.0.0=py38h2cd2533_2
-  - libnghttp2=1.47.0=hff17c54_1
-  - libnsl=2.0.0=h7f98852_0
-  - libpng=1.6.37=h21135ba_2
-  - libprotobuf=3.21.9=h6239696_0
-  - librsvg=2.54.4=h7abd40a_0
-  - libsolv=0.7.22=h6239696_0
-  - libsqlite=3.40.0=h753d276_0
-  - libssh2=1.10.0=hf14f497_3
-  - libstdcxx-ng=12.2.0=h46fd767_19
-  - libtiff=4.3.0=hf544144_1
-  - libtool=2.4.6=h9c3ff4c_1008
-  - libuuid=2.32.1=h7f98852_1000
-  - libuv=1.43.0=h7f98852_0
-  - libwebp=1.2.2=h3452ae3_0
-  - libwebp-base=1.2.2=h7f98852_1
-  - libxcb=1.13=h7f98852_1004
-  - libxml2=2.10.3=h7463322_0
-  - libzlib=1.2.13=h166bdaf_4
-  - llvm-openmp=15.0.5=he0ac6c6_0
-  - lz4-c=1.9.3=h9c3ff4c_1
-  - lzo=2.10=h516909a_1000
-  - mamba=1.0.0=py38haad2881_2
+  - lerc=3.0=h295c915_0
+  - libdeflate=1.8=h7f8727e_5
+  - libffi=3.4.2=h6a678d5_6
+  - libgcc-ng=11.2.0=h1234567_1
+  - libgomp=11.2.0=h1234567_1
+  - libiconv=1.16=h7f8727e_2
+  - libidn2=2.3.2=h7f8727e_0
+  - libpng=1.6.37=hbc83047_0
+  - libstdcxx-ng=11.2.0=h1234567_1
+  - libtasn1=4.16.0=h27cfd23_0
+  - libtiff=4.4.0=hecacb30_2
+  - libunistring=0.9.10=h27cfd23_0
+  - libuv=1.40.0=h7b6447c_0
+  - libwebp=1.2.4=h11a3e52_0
+  - libwebp-base=1.2.4=h5eee18b_0
+  - lz4-c=1.9.3=h295c915_1
   - mkl=2021.4.0=h06a4308_640
-  - mkl-service=2.4.0=py38h95df7f1_0
-  - mkl_fft=1.3.1=py38h8666266_1
-  - mkl_random=1.2.2=py38h1abd341_0
-  - multidict=6.0.2=py38h0a891b7_2
-  - nanotime=0.5.2=py_0
+  - mkl-service=2.4.0=py38h7f8727e_0
+  - mkl_fft=1.3.1=py38hd3c417c_0
+  - mkl_random=1.2.2=py38h51133e4_0
   - ncurses=6.3=h5eee18b_3
-  - nettle=3.6=he412f7d_0
-  - numpy=1.23.3=py38h14f4228_1
-  - numpy-base=1.23.3=py38h31eccc5_1
-  - oauth2client=4.1.3=py_0
-  - olefile=0.46=pyh9f0ad1d_1
-  - omegaconf=2.2.3=pyhd8ed1ab_0
-  - openh264=2.1.1=h780b84a_0
-  - openjpeg=2.4.0=hb52868f_1
-  - openssl=3.0.7=h166bdaf_0
-  - packaging=21.3=pyhd8ed1ab_0
-  - pango=1.50.9=hc4f8a73_0
-  - pathlib2=2.3.7.post1=py38h578d9bd_2
-  - pathspec=0.9.0=pyhd8ed1ab_0
-  - pcre2=10.40=hc3806b6_0
-  - pillow=8.3.2=py38h8e6f84c_0
+  - nettle=3.7.3=hbbd107a_1
+  - numpy=1.23.4=py38h14f4228_0
+  - numpy-base=1.23.4=py38h31eccc5_0
+  - openh264=2.1.1=h4ff587b_0
+  - openssl=1.1.1s=h7f8727e_0
+  - pillow=9.2.0=py38hace64e9_1
   - pip=22.2.2=py38h06a4308_0
-  - pixman=0.40.0=h36c2ea0_0
-  - ply=3.11=py_1
-  - prompt_toolkit=3.0.33=hd8ed1ab_0
-  - psutil=5.9.4=py38h0a891b7_0
-  - pthread-stubs=0.4=h36c2ea0_1001
-  - pyasn1=0.4.8=py_0
-  - pybind11-abi=4=hd8ed1ab_3
-  - pycosat=0.6.4=py38h0a891b7_1
-  - pycparser=2.21=pyhd8ed1ab_0
-  - pydot=1.4.2=py38h578d9bd_3
-  - pydrive2=1.15.0=pyhd8ed1ab_0
-  - pygit2=1.11.1=py38h0a891b7_0
-  - pygments=2.13.0=pyhd8ed1ab_0
-  - pygtrie=2.5.0=pyhd8ed1ab_0
-  - pyopenssl=22.1.0=pyhd8ed1ab_0
-  - pysocks=1.7.1=py38h578d9bd_5
-  - python=3.8.15=h4a9ceb5_0_cpython
-  - python-gssapi=1.8.2=py38hf949b76_1
-  - python_abi=3.8=2_cp38
-  - pytorch=1.10.1=py3.8_cuda11.3_cudnn8.2.0_0
+  - pycparser=2.21=pyhd3eb1b0_0
+  - pyopenssl=22.0.0=pyhd3eb1b0_0
+  - pysocks=1.7.1=py38h06a4308_0
+  - python=3.8.15=h7a1cb2a_2
+  - pytorch=1.11.0=py3.8_cuda11.3_cudnn8.2.0_0
   - pytorch-mutex=1.0=cuda
-  - pytz=2022.6=pyhd8ed1ab_0
-  - pyu2f=0.1.5=pyhd8ed1ab_0
-  - pywin32=304=py38h578d9bd_2
-  - pywin32-on-windows=0.1.0=pyh07e9846_2
-  - pyyaml=6.0=py38h0a891b7_5
   - readline=8.2=h5eee18b_0
-  - reproc=14.2.3=h7f98852_0
-  - reproc-cpp=14.2.3=h9c3ff4c_0
-  - requests=2.28.1=pyhd8ed1ab_1
-  - rich=12.6.0=pyhd8ed1ab_0
-  - rsa=4.9=pyhd8ed1ab_0
-  - ruamel.yaml=0.17.21=py38h0a891b7_2
-  - ruamel.yaml.clib=0.2.7=py38h0a891b7_0
-  - ruamel_yaml=0.15.80=py38h0a891b7_1008
-  - scmrepo=0.1.3=pyhd8ed1ab_0
-  - shortuuid=1.0.11=pyhd8ed1ab_0
-  - shtab=1.5.8=pyhd8ed1ab_0
-  - six=1.16.0=pyh6c4a22f_0
-  - sqlite=3.39.3=h5082296_0
-  - tabulate=0.9.0=pyhd8ed1ab_1
+  - requests=2.28.1=py38h06a4308_0
+  - setuptools=65.5.0=py38h06a4308_0
+  - six=1.16.0=pyhd3eb1b0_1
+  - sqlite=3.40.0=h5082296_0
   - tk=8.6.12=h1ccaba5_0
-  - toml=0.10.2=pyhd8ed1ab_0
-  - tomlkit=0.11.6=pyha770c72_0
-  - toolz=0.12.0=pyhd8ed1ab_0
-  - torchaudio=0.10.1=py38_cu113
-  - torchvision=0.11.2=py38_cu113
-  - tqdm=4.64.1=pyhd8ed1ab_0
-  - typing=3.10.0.0=pyhd8ed1ab_0
-  - typing-extensions=4.4.0=hd8ed1ab_0
-  - typing_extensions=4.4.0=pyha770c72_0
-  - uritemplate=4.1.1=pyhd8ed1ab_0
-  - vine=5.0.0=pyhd8ed1ab_1
-  - voluptuous=0.13.1=pyhd8ed1ab_0
-  - wcwidth=0.2.5=pyh9f0ad1d_2
+  - torchaudio=0.11.0=py38_cu113
+  - torchvision=0.12.0=py38_cu113
+  - typing_extensions=4.3.0=py38h06a4308_0
+  - urllib3=1.26.12=py38h06a4308_0
   - wheel=0.37.1=pyhd3eb1b0_0
-  - xorg-kbproto=1.0.7=h7f98852_1002
-  - xorg-libice=1.0.10=h7f98852_0
-  - xorg-libsm=1.2.3=hd9c2040_1000
-  - xorg-libx11=1.7.2=h7f98852_0
-  - xorg-libxau=1.0.9=h7f98852_0
-  - xorg-libxdmcp=1.1.3=h7f98852_0
-  - xorg-libxext=1.3.4=h7f98852_1
-  - xorg-libxrender=0.9.10=h7f98852_1003
-  - xorg-renderproto=0.11.1=h7f98852_1002
-  - xorg-xextproto=7.3.0=h7f98852_1002
-  - xorg-xproto=7.0.31=h7f98852_1007
   - xz=5.2.6=h5eee18b_0
-  - yaml=0.2.5=h7f98852_2
-  - yaml-cpp=0.7.0=h27087fc_2
-  - yarl=1.8.1=py38h0a891b7_0
-  - zc.lockfile=2.0=pyhd8ed1ab_1
-  - zipp=3.10.0=pyhd8ed1ab_0
-  - zlib=1.2.13=h166bdaf_4
-  - zstd=1.5.2=h6239696_4
+  - zlib=1.2.13=h5eee18b_0
+  - zstd=1.5.2=ha4553b6_0
   - pip:
     - absl-py==1.3.0
-    - asttokens==2.1.0
-    - astunparse==1.6.3
+    - aiohttp==3.8.3
+    - aiohttp-retry==2.8.3
+    - aiosignal==1.3.1
+    - amqp==5.1.1
+    - antlr4-python3-runtime==4.9.3
+    - appdirs==1.4.4
+    - async-timeout==4.0.2
+    - asyncssh==2.12.0
     - atpublic==3.1.1
-    - backcall==0.2.0
-    - black==22.10.0
+    - attrs==22.1.0
+    - billiard==3.6.4.0
+    - cachetools==5.2.0
+    - celery==5.2.7
+    - click==8.1.3
+    - click-didyoumean==0.3.0
+    - click-plugins==1.1.1
+    - click-repl==0.2.0
+    - colorama==0.4.6
+    - commonmark==0.9.1
     - configobj==5.0.6
     - contourpy==1.0.6
     - cycler==0.11.0
+    - dictdiffer==0.9.0
+    - diskcache==5.4.0
     - distro==1.8.0
-    - dpath==2.0.7
-    - dvc==2.34.3
+    - dpath==2.0.8
+    - dulwich==0.20.50
+    - dvc==2.35.2
     - dvc-data==0.28.0
+    - dvc-gdrive==2.19.1
+    - dvc-http==2.27.2
     - dvc-objects==0.14.0
     - dvc-render==0.0.14
     - dvc-task==0.1.6
-    - executing==1.2.0
-    - flatbuffers==22.10.26
+    - dvclive==1.0.1
+    - filelock==3.8.0
+    - flatten-dict==0.4.2
     - flufl-lock==7.1.1
     - fonttools==4.38.0
-    - gast==0.4.0
-    - gitdb==4.0.9
+    - frozenlist==1.3.3
+    - fsspec==2022.11.0
+    - funcy==1.17
+    - future==0.18.2
+    - gitdb==4.0.10
+    - gitpython==3.1.29
+    - google-api-core==2.11.0
+    - google-api-python-client==2.80.0
+    - google-auth==2.14.1
+    - google-auth-httplib2==0.1.0
     - google-auth-oauthlib==0.4.6
-    - google-pasta==0.2.0
-    - googleapis-common-protos==1.57.0
+    - googleapis-common-protos==1.58.0
+    - grandalf==0.6
     - grpcio==1.50.0
-    - h5py==3.7.0
-    - ipython==8.6.0
-    - jedi==0.18.1
-    - keras==2.10.0
-    - keras-preprocessing==1.1.2
+    - httplib2==0.21.0
+    - hydra-core==1.2.0
+    - importlib-metadata==5.1.0
+    - importlib-resources==5.10.0
+    - iterative-telemetry==0.0.6
     - kiwisolver==1.4.4
-    - libclang==14.0.6
+    - kombu==5.2.4
     - markdown==3.4.1
     - markupsafe==2.1.1
     - matplotlib==3.6.2
-    - matplotlib-inline==0.1.6
-    - mypy-extensions==0.4.3
+    - multidict==6.0.2
+    - nanotime==0.5.2
     - networkx==2.8.8
+    - oauth2client==4.1.3
     - oauthlib==3.2.2
+    - omegaconf==2.2.3
     - opencv-python==4.6.0.66
-    - opt-einsum==3.3.0
-    - pandas==1.5.1
-    - parso==0.8.3
-    - pexpect==4.8.0
-    - pickleshare==0.7.5
-    - platformdirs==2.5.4
-    - prompt-toolkit==3.0.32
-    - protobuf==3.19.6
-    - ptyprocess==0.7.0
-    - pure-eval==0.2.2
+    - packaging==21.3
+    - pandas==1.5.2
+    - pathspec==0.9.0
+    - prompt-toolkit==3.0.33
+    - protobuf==3.20.3
+    - psutil==5.9.4
+    - pyasn1==0.4.8
     - pyasn1-modules==0.2.8
+    - pydot==1.4.2
+    - pydrive2==1.15.1
+    - pygit2==1.11.1
+    - pygments==2.13.0
+    - pygtrie==2.5.0
     - pyparsing==3.0.9
     - python-dateutil==2.8.2
+    - pytz==2022.6
+    - pyyaml==6.0
     - requests-oauthlib==1.3.1
+    - rich==12.6.0
+    - rsa==4.9
+    - ruamel-yaml==0.17.21
+    - ruamel-yaml-clib==0.2.7
     - scipy==1.9.3
+    - scmrepo==0.1.3
     - seaborn==0.12.1
-    - setuptools==59.5.0
+    - shortuuid==1.0.11
+    - shtab==1.5.8
     - smmap==5.0.0
-    - stack-data==0.6.1
-    - tensorboard==2.10.1
+    - tabulate==0.9.0
+    - tensorboard==2.11.0
     - tensorboard-data-server==0.6.1
     - tensorboard-plugin-wit==1.8.1
-    - tensorflow==2.10.1
-    - tensorflow-estimator==2.10.0
-    - tensorflow-io-gcs-filesystem==0.27.0
-    - termcolor==2.1.0
-    - thop==0.1.1-2209072238
-    - tomli==2.0.1
-    - traitlets==5.5.0
-    - urllib3==1.26.12
+    - tomlkit==0.11.6
+    - tqdm==4.64.1
+    - uritemplate==4.1.1
+    - vine==5.0.0
+    - voluptuous==0.13.1
+    - wcwidth==0.2.5
     - werkzeug==2.2.2
-    - wrapt==1.14.1
+    - yarl==1.8.1
+    - zc-lockfile==2.0
+    - zipp==3.11.0
 prefix: /home/xintian/miniconda2/envs/yolov7
 

--- a/torch-to-tflite/test-tflite.py
+++ b/torch-to-tflite/test-tflite.py
@@ -9,7 +9,7 @@ import cv2
 import tensorflow as tf
 import torch
 
-
+RESIZE_SCALE = 0.58 # Use the same resize scale as the one calculated during training.
 PAD_COLOR = (114, 114, 114)
 NAMES = {0: "empty", 1: "yes", 2: "no", 3: "both", 4: "invalid"}
 
@@ -30,7 +30,6 @@ def test_tflite(
     output_dir.mkdir(exist_ok=True, parents=True)
     assert input_data_path.is_dir(), f"{input_data_path} is not a directory."
     for img_path in Path(input_data_path).glob("*.*[Gg]"):
-        print("-" * 100 + f"\nLoading input data from {img_path} ...")
         img = cv2.imread(str(img_path))
         input_data = _preprocess_input(img, input_shape)
         output_tensor = my_signature(input=input_data / 255)["output"]
@@ -49,9 +48,7 @@ def _preprocess_input(img: Path, input_shape: List[int]) -> np.ndarray:
     img_h, img_w, _ = img.shape
     max_img_size = max(img_h, img_w)
     max_target_size = max(target_h, target_w)
-    resize_scale = (
-        max_target_size / max_img_size if max_target_size < max_img_size else 1
-    )
+    resize_scale = min( [max_target_size / max_img_size, RESIZE_SCALE] )
     resized_img = cv2.resize(
         img, (int(resize_scale * img_w), int(resize_scale * img_h))
     )

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -35,7 +35,6 @@ help_url = 'https://github.com/ultralytics/yolov5/wiki/Train-Custom-Data'
 img_formats = ['bmp', 'jpg', 'jpeg', 'png', 'tif', 'tiff', 'dng', 'webp', 'mpo', 'PNG', 'JPG']  # acceptable image suffixes
 vid_formats = ['mov', 'avi', 'mp4', 'mpg', 'mpeg', 'm4v', 'wmv', 'mkv']  # acceptable video suffixes
 logger = logging.getLogger(__name__)
-TRAIN_WITH_RECT_INPUT = False
 
 # Get orientation exif tag
 for orientation in ExifTags.TAGS.keys():
@@ -145,7 +144,13 @@ class LoadImages:  # for inference
         self.img_size = img_size
         self.stride = stride
         self.files = images + videos
-        self.resize_scale = img_size / max([cv2.imread(img_path).shape[0] for img_path in self.files])
+        self.resize_scale = 0.5818 # we use LoadImages in detect.py only thus we set resize_scale to the same number as it is calculated during training.
+        print(
+            f""" 
+                !!! !!! Current resize scale is {self.resize_scale} !!! !!!
+                Please check if it is the same with the training process 
+            """
+            )
         self.nf = ni + nv  # number of files
         self.video_flag = [False] * ni + [True] * nv
         self.mode = 'image'
@@ -383,7 +388,13 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
             self.img_files = sorted([x.replace('/', os.sep) for x in f if x.split('.')[-1].lower() in img_formats])
             # self.img_files = sorted([x for x in f if x.suffix[1:].lower() in img_formats])  # pathlib
             assert self.img_files, f'{prefix}No images found'
-            self.resize_scale = img_size / max([cv2.imread(img_path).shape[0] for img_path in self.img_files])
+            self.resize_scale = img_size / max([max(cv2.imread(img_file).shape) for img_file in self.img_files]) 
+            print(
+                f"""
+                    !!! !!! Current resizing scale is {self.resize_scale} !!!!!!
+          !!! !!! Please use the same scale for validation, testing and deployment !!! !!!
+                """
+            )
         except Exception as e:
             raise Exception(f'{prefix}Error loading data from {path}: {e}\nSee {help_url}')
 
@@ -583,13 +594,13 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
             #img, labels = self.albumentations(img, labels)
 
             # Augment colorspace
-            augment_hsv(img, hgain=hyp['hsv_h'], sgain=hyp['hsv_s'], vgain=hyp['hsv_v'])
+            augment_hsv(img, hgain=hyp['hsv_h'], sgain=hyp['hsv_s'], vgain=hyp['hsv_v']) # Decrease color gains in config.
 
             # Apply cutouts
             # if random.random() < 0.9:
             #     labels = cutout(img, labels)
             
-            if random.random() < hyp['paste_in']:
+            if random.random() < hyp['paste_in']: # Set paste_in probability to 0 in config.
                 sample_labels, sample_images, sample_masks = [], [], [] 
                 while len(sample_labels) < 30:
                     sample_labels_, sample_images_, sample_masks_ = load_samples(self, random.randint(0, len(self.labels) - 1))
@@ -984,8 +995,6 @@ def letterbox(img, new_shape=(640, 640), color=(114, 114, 114), auto=True, scale
     shape = img.shape[:2]  # current shape [height, width]
     if isinstance(new_shape, int):
         new_shape = [new_shape, new_shape]
-    if TRAIN_WITH_RECT_INPUT:
-        new_shape[1] = 256
     # Scale ratio (new / old)
     r = resize_scale
     if not scaleup:  # only scale down, do not scale up (for better test mAP)

--- a/utils/general.py
+++ b/utils/general.py
@@ -614,12 +614,12 @@ def non_max_suppression(prediction, conf_thres=0.25, iou_thres=0.45, classes=Non
     """
 
     nc = prediction.shape[2] - 5  # number of classes
-    xc = prediction[..., 4] > conf_thres  # candidates
+    xc = prediction[..., 4] > conf_thres  # candidate based on obj detection conf
 
     # Settings
-    min_wh, max_wh = 2, 4096  # (pixels) minimum and maximum box width and height
+    # min_wh, max_wh = 15, 90  # (pixels) minimum and maximum box width and height
     max_det = 300  # maximum number of detections per image
-    max_nms = 30000  # maximum number of boxes into torchvision.ops.nms()
+    max_nms = 3000 # maximum number of boxes into torchvision.ops.nms()
     time_limit = 10.0  # seconds to quit after
     redundant = True  # require redundant detections
     multi_label &= nc > 1  # multiple labels per box (adds 0.5ms/img)
@@ -630,7 +630,7 @@ def non_max_suppression(prediction, conf_thres=0.25, iou_thres=0.45, classes=Non
     for xi, x in enumerate(prediction):  # image index, image inference
         # Apply constraints
         # x[((x[..., 2:4] < min_wh) | (x[..., 2:4] > max_wh)).any(1), 4] = 0  # width-height
-        x = x[xc[xi]]  # confidence
+        x = x[xc[xi]]  # boolean list true while prediction[..., 4] > conf_thres
 
         # Cat apriori labels if autolabelling
         if labels and len(labels[xi]):
@@ -655,13 +655,10 @@ def non_max_suppression(prediction, conf_thres=0.25, iou_thres=0.45, classes=Non
         # Box (center x, center y, width, height) to (x1, y1, x2, y2)
         box = xywh2xyxy(x[:, :4])
 
-        # Detections matrix nx6 (xyxy, conf, cls)
-        if multi_label:
-            i, j = (x[:, 5:] > conf_thres).nonzero(as_tuple=False).T
-            x = torch.cat((box[i], x[i, j + 5, None], j[:, None].float()), 1)
-        else:  # best class only
-            conf, j = x[:, 5:].max(1, keepdim=True)
-            x = torch.cat((box, conf, j.float()), 1)[conf.view(-1) > conf_thres]
+        conf, j = x[:, 5:].max(1, keepdim=True) # get classconf and class_idx
+        # orig_conf = (conf / x[:, 4:5])[conf.view(-1) > conf_thres][:,0]  # original conf
+        # obj_conf = x[:, 4:5][conf.view(-1) > conf_thres][:,0]  # original obj_conf
+        x = torch.cat((box, conf, j.float()), 1)[conf.view(-1) > conf_thres]
 
         # Filter by class
         if classes is not None:
@@ -680,6 +677,8 @@ def non_max_suppression(prediction, conf_thres=0.25, iou_thres=0.45, classes=Non
 
         # Batched NMS
         boxes, scores = x[:, :4], x[:, 4]  # boxes (offset by class), scores
+        # c = x[:, 5:6] * (0 if agnostic else max_wh)  # classes
+        # boxes, scores = x[:, :4] + c, x[:, 4]  # boxes (offset by class), scores
         i = torchvision.ops.nms(boxes, scores, iou_thres)  # NMS
         if i.shape[0] > max_det:  # limit detections
             i = i[:max_det]
@@ -775,8 +774,9 @@ def non_max_suppression_kpt(prediction, conf_thres=0.25, iou_thres=0.45, classes
             x = x[x[:, 4].argsort(descending=True)[:max_nms]]  # sort by confidence
 
         # Batched NMS
-        c = x[:, 5:6] * (0 if agnostic else max_wh)  # classes
-        boxes, scores = x[:, :4] + c, x[:, 4]  # boxes (offset by class), scores
+        boxes, scores = x[:, :4], x[:, 4]  # boxes (offset by class), scores
+        # c = x[:, 5:6] * (0 if agnostic else max_wh)  # classes
+        # boxes, scores = x[:, :4] + c, x[:, 4]  # boxes (offset by class), scores
         i = torchvision.ops.nms(boxes, scores, iou_thres)  # NMS
         if i.shape[0] > max_det:  # limit detections
             i = i[:max_det]


### PR DESCRIPTION
In the previous experiments, using rectangular images as input data during training to reduce model size and increase detection speed downgrade the model performance significantly. Thus, remove using rectangular images as input data during training. Convert the square input shape into rectangular shape to reduce the model size and increase the detection speed while converting a pretrained model into tflite model.

Use the same resize scale in testing as used in training and validation to resize input images. Previously the resize scale used in testing is calculated based on the testing dataset, however the testing dataset is much smaller than the training one. It is likely happen that the resize scale calculated based on the testing dataset is not the same as the one used in training and validation. Thus, hard code the resize scale in testing script to be the same as the one used in training and validation.

Same for testing tflite models, use the same resize scale as used in training and validation.

Use only the class with the highest classification confidence in the nms algorithm.

To be compatible with `DVC` and `TensorFlow` used for converting a `torch` model into a `tflite` one, the `conda` environment is updated. Update the environment file accordingly.